### PR TITLE
20200514 cli error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 const fs = require('fs');
+const util = require('util');
 
 (async () => {
-  const res = await require('./main.js').jenkinsToCCI(fs.readFileSync(process.argv[2])).catch((err) => console.error(err));
+  const res = await require('./main.js').jenkinsToCCI(fs.readFileSync(process.argv[2])).catch((err) => err);
 
   console.log(res);
 
   if (process.argv[3]) {
-    fs.writeFileSync(process.argv[3], res);
+    fs.writeFileSync(process.argv[3], util.format(res));
   }
 })();

--- a/index.js
+++ b/index.js
@@ -7,6 +7,6 @@ const util = require('util');
   console.log(res);
 
   if (process.argv[3]) {
-    fs.writeFileSync(process.argv[3], util.format(res));
+    fs.writeFileSync(process.argv[3], `${util.format(res)}\n`);
   }
 })();

--- a/test/validateConfigs.sh
+++ b/test/validateConfigs.sh
@@ -13,8 +13,8 @@ validate_configs() {
       if ! circleci config validate "${configs[i]}"
       then
         ((failed++)) 
-        echo "Failed to validate ${configs[i]} - below is the contents of ${configs[i]}:"
         cat ${configs[i]}
+        echo "Failed to validate ${configs[i]}"
       else
         ((passed++))
       fi

--- a/test/validateConfigs.sh
+++ b/test/validateConfigs.sh
@@ -13,7 +13,8 @@ validate_configs() {
       if ! circleci config validate "${configs[i]}"
       then
         ((failed++)) 
-        echo "Failed to validate ${configs[i]}"
+        echo "Failed to validate ${configs[i]} - below is the contents of ${configs[i]}:"
+        cat ${configs[i]}
       else
         ((passed++))
       fi


### PR DESCRIPTION
Changed two things:

* `index.js` was not generating a meaningful file if the backend Jenkins failed to generate a JSON. This was changed and now error messages from the parser will be put to `process.argv[3]`.
* `test/validateConfigs.sh` now shows the contents of config.yml which failed to pass `circleci config validate`. This intends to help assessing the result of `test/validateConfigs.sh`, as it would show an error message from the parser side as well.