### PR TITLE
20200521 error messages in array

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,10 +19,19 @@ const jenkinsToCCI = async (jenkinsfile) => {
 
   try {
     if (fromJenkins.data.result === 'failure') {
-      let errorMsgArr = ['Failed to parse your Jenkinsfile. It happens especially if your Jenkinsfile is relying on unsupported plugins - in such cases, removing stanzas mentioned below will suppress the error.\nHere are error messages from the parser:'];
+      let errCtr = 0;
 
-      fromJenkins.data.errors.forEach((errorObj, index) => {
-        errorMsgArr.push(`${index + 1}. ${errorObj.error}`);
+      const errorMsgArr = ['Failed to parse your Jenkinsfile. It happens especially if your Jenkinsfile is relying on unsupported plugins - in such cases, removing stanzas mentioned below will suppress the error.\nHere are error messages from the parser:'];
+      const pushErrMsg = (msg) => {
+        if (Array.isArray(msg)) {
+          msg.forEach(pushErrMsg);
+        } else {
+          errorMsgArr.push(`${++errCtr}. ${msg}`);
+        }
+      }
+
+      fromJenkins.data.errors.forEach((errorObj) => {
+        pushErrMsg(errorObj.error);
       });
 
       isFinal = true;


### PR DESCRIPTION
With this change the error message like this

```
1. Invalid parameter "zipFile", did you mean "label"? @ line 110, column 8.,Invalid parameter "dir", did you mean "url"? @ line 110, column 34.,Tool type "maven" does not have an install of "Maven 3.6.3" configured - did you mean "null"? @ line 11, column 9.,Tool type "jdk" does not have an install of "Corretto 8.232" configured - did you mean "null"? @ line 12, column 7.

    at Object.jenkinsToCCI (/server.js:326:39434)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

will become like this

```
1. Invalid parameter "zipFile", did you mean "label"? @ line 110, column 8.

2. Invalid parameter "dir", did you mean "url"? @ line 110, column 34.

3. Tool type "maven" does not have an install of "Maven 3.6.3" configured - did you mean "null"? @ line 11, column 9.

4. Tool type "jdk" does not have an install of "Corretto 8.232" configured - did you mean "null"? @ line 12, column 7.

    at Object.jenkinsToCCI (/home/makoto/jenkinsfile-converter/main.js:40:13)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async /home/makoto/jenkinsfile-converter/index.js:5:15
```