### PR TITLE
Migration to ECS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,10 +146,12 @@ jobs:
           command: |
             echo "export __BUILD_VERSION=\"$(cat version.txt)\"" >> $BASH_ENV
       - docker/build:
+          registry: $AWS_ECR_ACCOUNT_URL
           image: $JFC_MONOLITH_IMAGE_NAME
           tag: $__BUILD_VERSION
       - aws-ecr/ecr-login
       - docker/push:
+          registry: $AWS_ECR_ACCOUNT_URL
           image: $JFC_MONOLITH_IMAGE_NAME
           tag: $__BUILD_VERSION
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2.1
 
 orbs:
-  docker: circleci/docker@1.0.1
+  aws-ecr: circleci/aws-ecr@6.12.2
+  docker: circleci/docker@1.4.0
 
 jobs:
   build-and-unit-test-base:
@@ -98,8 +99,6 @@ jobs:
       - run:
           name: webpack base module
           command: npm run build
-          environment:
-            __JENKINS_TARGET: "http://jenkins.jfc-containers.local:8080/pipeline-model-converter/toJson"
       - store_artifacts:
           path: dist/jfc-module.js
       - run:
@@ -122,8 +121,6 @@ jobs:
           command: |
             export __BUILD_VERSION="$(cat version.txt)"
             yarn build
-          environment:
-            __JENKINS_TARGET: "http://jenkins.jfc-containers.local:8080/pipeline-model-converter/toJson"
           working_directory: server
       - store_artifacts:
           path: server/dist/server.js
@@ -140,7 +137,7 @@ jobs:
 
   build-docker-image:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202008-01
     steps:
       - attach_workspace:
           at: ./
@@ -148,13 +145,12 @@ jobs:
           name: Restore version info
           command: |
             echo "export __BUILD_VERSION=\"$(cat version.txt)\"" >> $BASH_ENV
-      - docker/check:
-          registry: $DOCKER_REGISTRY
       - docker/build:
-          image: $DOCKER_IMAGE_NAME
+          image: $JFC_MONOLITH_IMAGE_NAME
           tag: $__BUILD_VERSION
+      - aws-ecr/ecr-login
       - docker/push:
-          image: $DOCKER_IMAGE_NAME
+          image: $JFC_MONOLITH_IMAGE_NAME
           tag: $__BUILD_VERSION
 
 workflows:
@@ -184,4 +180,4 @@ workflows:
       - build-docker-image:
           requires:
             - clean-build-for-docker-image
-          context: jfc-dockerhub
+          context: jfc-ecr

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ const querystring = require('querystring');
 const { map } = require('./mapping/mapper.js');
 const { UpperStreamError, ParseFailure, MapperError } = require('./errors.js');
 
-const jenkinsTarget = (typeof __JENKINS_TARGET === typeof '' && __JENKINS_TARGET !== '') ? __JENKINS_TARGET : 'https://jenkinsto.cc/i/to-json';
+const jenkinsTarget = process.env.JFC_JENKINS_URL ? process.env.JFC_JENKINS_URL : 'https://jenkinsto.cc/i/to-json';
 
 // Main from here
 const jenkinsToCCI = async (jenkinsfile, rid = '') => {

--- a/server/assets/cli.html
+++ b/server/assets/cli.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Jenkinsfile Converter for CircleCI</title>
 
     <style>
@@ -30,7 +30,7 @@
 
     <script>
         const convert = async (jfString) => {
-            return await fetch('https://jenkinsto.cc/i', {
+            return await fetch('/i', {
                 method: 'POST',
                 mode: 'cors',
                 headers: {

--- a/server/src/responders/JenkinsToCCIResponder.test.ts
+++ b/server/src/responders/JenkinsToCCIResponder.test.ts
@@ -172,9 +172,7 @@ describe('convertJenkinsfileToJSON', () => {
             (<unknown>res) as express.Response
         );
 
-        Object.defineProperty(global, '__JENKINS_TARGET', {
-            value: 'https://jenkins.example.com/'
-        });
+        process.env.JFC_JENKINS_URL = 'https://jenkins.example.com/';
 
         await JenkinsToCCIResponder.convertJenkinsfileToJSON(
             serviceMocks,

--- a/server/src/responders/JenkinsToCCIResponder.ts
+++ b/server/src/responders/JenkinsToCCIResponder.ts
@@ -10,8 +10,6 @@ import type * as express from 'express';
 import type { ExpressWrapper } from '../ExpressWrapper';
 import type { AmplitudeClientService } from '../services/AmplitudeClientService.js';
 
-declare const __JENKINS_TARGET: string;
-
 /* istanbul ignore next */
 require.extensions &&
     (require.extensions['.html'] = (module: NodeJS.Module, filename: string) =>
@@ -100,8 +98,8 @@ class JenkinsToCCIResponder {
 
         return axios.default
             .post(
-                typeof __JENKINS_TARGET === typeof '' && __JENKINS_TARGET !== ''
-                    ? __JENKINS_TARGET
+                process.env.JFC_JENKINS_URL
+                    ? process.env.JFC_JENKINS_URL
                     : 'https://jenkinsto.cc/i/to-json',
                 req.body.toString('utf-8'),
                 {

--- a/server/webpack.config.js
+++ b/server/webpack.config.js
@@ -52,9 +52,6 @@ module.exports = (env, argv) => {
                     `${process.env.__BUILD_VERSION || 'unversioned'}-${
                         argv.mode === 'production' ? 'prod' : 'devel'
                     }`
-                ),
-                __JENKINS_TARGET: JSON.stringify(
-                    process.env.__JENKINS_TARGET || ''
                 )
             })
         ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,8 +33,7 @@ module.exports = (env, argv) => {
                     `${process.env.__BUILD_VERSION || 'unversioned'}-${
                     argv.mode === 'production' ? 'prod' : 'devel'
                     }`
-                ),
-                __JENKINS_TARGET: JSON.stringify(process.env.__JENKINS_TARGET || '')
+                )
             })
         ],
         target: 'node'


### PR DESCRIPTION
Originally, we were using @makotom's personal Docker Hub repository. 🙀 This PR intends to stop doing so, considering concerns on sustainability, and aims to push images to CircleCI's own ECR instead.

This change is ongoing along with the backend Jenkins (cf. https://github.com/circleci/jfc-jenkins/pull/1). This is why this PR includes a change to specify the URL of backend Jenkins via environment variable.